### PR TITLE
Acerto na linha de crédito da tradução - heroku

### DIFF
--- a/_posts/2012-04-18-app.markdown
+++ b/_posts/2012-04-18-app.markdown
@@ -6,8 +6,9 @@ permalink: app
 
 # Tutorial para criação da app Rails Girls
 
-*Criado por Vesa Vänskä, [@vesan](https://twitter.com/vesan)*
+*Criado por Vesa Vänskä, [@vesan](https://twitter.com/vesan)*  
 *Traduzido por Maujor, [site do Maujor](http://www.maujor.com)*
+
 
 **Você deverá ter Rails instalado.** [**Consulte o guia de instalação se você ainda não instalou.**](install)
 

--- a/_posts/2012-04-19-contributing.markdown
+++ b/_posts/2012-04-19-contributing.markdown
@@ -6,6 +6,8 @@ permalink: contributing
 
 # Instruções para contribuir com um tutorial
 
+*Traduzido por Maujor, [site do Maujor](http://www.maujor.com)* 
+
 O site de tutoriais usa a tecnologia [jekyll](https://github.com/mojombo/jekyll) para renderizar suas páginas e todos os documentos do site são escritos com uso da sintaxe [markdown](http://daringfireball.net/projects/markdown/). Para contribuir com um ou mais  ( ;-) ) tutoriais siga os seguinte passos: 
 
 1. Dê um fork no [repositório do github](https://github.com/railsgirlsmaceio/railsgirlsguides) clicando no botão "Fork".

--- a/_posts/2012-04-19-contributing.markdown
+++ b/_posts/2012-04-19-contributing.markdown
@@ -1,29 +1,30 @@
 ---
 layout: default
-title: Contributing a Guide
+title: Contribua com um tutorial
 permalink: contributing
 ---
 
-# Contributing a Guide
+# Instruções para contribuir com um tutorial
 
-The guides site uses [jekyll](https://github.com/mojombo/jekyll) to power the site and all the documents are written using [markdown](http://daringfireball.net/projects/markdown/). To contribute a guide, you just need to follow these simple steps.
+O site de tutoriais usa a tecnologia [jekyll](https://github.com/mojombo/jekyll) para renderizar suas páginas e todos os documentos do site são escritos com uso da sintaxe [markdown](http://daringfireball.net/projects/markdown/). Para contribuir com um ou mais  ( ;-) ) tutoriais siga os seguinte passos: 
 
-1. Fork the [repository on github](https://github.com/railsgirls/railsgirls.github.com) by clicking on the "Fork" button.
-2. Do a `git clone` of your fork.
-3. Create a file named `YYYY-MM-DD-guide_name.markdown` inside the `_posts` directory of your fork.
-4. In this file, you'll need to add some YAML front matter at the top of the file so it looks like the following example, taken from this guide that you are currently viewing:
+1. Dê um fork no [repositório do github](https://github.com/railsgirlsmaceio/railsgirlsguides) clicando no botão "Fork".
+2. Execute o comando `git clone` no seu fork.
+3. Crie um arquivo denominado `YYYY-MM-DD-nome_do_tutorial.markdown` e salve no diretório `_posts` do seu fork.
+4. No início do arquivo recém criado  use a sintaxe YAML para serializar alguns dados que são padronizados para os tutoriais. Veja um exemplo destes dados que se aplica a este documento que você está visualizando:
 
     <pre>
     ---
     layout: default
-    title: Contributing a Guide
+    title: Contribua com um tutorial
     permalink: contributing
     ---</pre>
 
-5. Commit this new guide to your git repo.
-6. After you commit, push that to your fork.
-7. You can now open a pull request explaining your guide. That's it!
+5. A seguir escreva seu tutorial usando a sintaxe markdown.
+6. Commit seu tutorial para o seu repositório.
+7. Feito o commit envie-o para seu fork.
+8. Finalmente abra um pull request e nele acrescente uma breve descrição do seu tutorial. Feito!
 
-You can follow the structure of our [Rails Girls App Tutorial](https://github.com/railsgirls/railsgirls.github.com/blob/master/_posts/2012-04-18-app.markdown).
+Você pode tomar como base para seu tutorial a estrutura do tutorial [Rails Girls App Tutorial](https://github.com/railsgirlsmaceio/railsgirlsguides/blob/gh-pages/_posts/2012-04-18-app.markdown).
 
-Thanks so much for taking the time to help us make Rails Girls awesome.
+Nossos mais efusivos agradecimentos por dedicar seu tempo em favor do enriquecimento dos conteúdos do site Rails Girls.

--- a/_posts/2012-04-19-heroku.markdown
+++ b/_posts/2012-04-19-heroku.markdown
@@ -7,6 +7,7 @@ permalink: heroku
 # Publique sua aplicação com Heroku
 
 *Criado por Terence Lee, [@hone02](https://twitter.com/hone02)*
+
 *Traduzido por Maujor, [site do Maujor](http://www.maujor.com)*
 
 ### Instale Heroku


### PR DESCRIPTION
Considero melhor separar as linhas dos crédito do autor e do tradutor.
Marina: Usar parágrafo ou line break para separar? Por favor escolha o que você considera melhor e vamos padronizar.
Na minha opinião seria melhor line-break e não parágrafo como eu fiz. Acho que parágrafo acrescenta muito espaçamento entre as linhas, contudo a decisão é sua.
